### PR TITLE
Feature/bcabanayan/add number format to phone field

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -30,6 +30,7 @@
     "react-autosuggest": "^9.4.3",
     "react-dom": "^16.8.4",
     "react-firebaseui": "^3.1.2",
+    "react-number-format": "^4.0.7",
     "react-redux": "^6.0.1",
     "react-router-dom": "^4.3.1",
     "react-scripts": "2.1.5",

--- a/client/src/components/Settings/OptEmailsTextsForm.js
+++ b/client/src/components/Settings/OptEmailsTextsForm.js
@@ -16,9 +16,6 @@ import Typography from "@material-ui/core/Typography";
 import styles from './styles';
 
 class OptEmailsTextsForm extends React.Component {
-    constructor(props){
-        super(props);
-    };
 
     componentDidMount(){
         const uid = firebase.auth().currentUser.uid;

--- a/client/src/components/Settings/PhoneForm.js
+++ b/client/src/components/Settings/PhoneForm.js
@@ -62,14 +62,14 @@ class PhoneForm extends React.Component {
                         {/* Current phone number */}
                         <p className={classes.currentValue}>{this.props.settings.phoneNumber}</p>
                     </div>
-
-                    {/* Text field for new phone number */}
+                {/* New phone number form */}
                 <form
                     id='phoneForm'
                     onSubmit={this.handleSubmit}
                     className={classes.phoneField}
                 >
-                    <TextField 
+                    {/* Text field for new phone number */}
+                    <NumberFormat 
                         name='phoneNumber'
                         label='Type new phone'
                         variant="outlined"
@@ -78,7 +78,11 @@ class PhoneForm extends React.Component {
                         onChange={this.handleChange}
                         margin='normal'
                         inputProps={{
-                            style: { textAlign: "right" }}}
+                            style: { textAlign: "right" }}
+                        }
+                        format="+1 (###) ###-####" 
+                        mask="_" 
+                        customInput={TextField}
                     />
                     {/* Button to submit new phone number */}
                     <Button 

--- a/client/src/components/Settings/PhoneForm.js
+++ b/client/src/components/Settings/PhoneForm.js
@@ -15,6 +15,9 @@ import Collapse from '@material-ui/core/Collapse';
 // WithStyles
 import styles from './styles';
 
+// NumberFormat for text input
+import NumberFormat from 'react-number-format';
+
 class PhoneForm extends React.Component {
     constructor(props){
         super(props);

--- a/client/src/components/Settings/PhoneForm.js
+++ b/client/src/components/Settings/PhoneForm.js
@@ -10,7 +10,6 @@ import { withStyles } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField'; 
 import Button from '@material-ui/core/Button';
 import Typography from "@material-ui/core/Typography";
-import Collapse from '@material-ui/core/Collapse';
 
 // WithStyles
 import styles from './styles';

--- a/client/src/components/Settings/index.js
+++ b/client/src/components/Settings/index.js
@@ -15,9 +15,6 @@ import PhoneForm from './PhoneForm';
 import OptEmailsTextsForm from './OptEmailsTextsForm';
 
 class Settings extends React.Component {
-    constructor(){
-        super();
-    };
 
     handleChange = name => event => {
         this.setState({ [name]: event.target.value });

--- a/client/src/components/Settings/styles.js
+++ b/client/src/components/Settings/styles.js
@@ -1,5 +1,3 @@
-import { elementType } from "prop-types";
-
 const styles = theme => ({
     parent: {
         display: 'flex',

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -10072,6 +10072,13 @@ react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-number-format@^4.0.7:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-4.0.7.tgz#b3294b95bcadfbbec1b7e86740c3950818f532bc"
+  integrity sha512-boRHwPzkNDuyqeQ9zyHp0XgVAqT5RyS+BsohOhiTz6VMxEQr3DuSuNdg0Q8c3CYTgNESYlxnH278DPqaQFO72w==
+  dependencies:
+    prop-types "^15.6.0"
+
 react-redux@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-6.0.1.tgz#0d423e2c1cb10ada87293d47e7de7c329623ba4d"


### PR DESCRIPTION
# Description

I added the react-number-format dependency so that I could implement the NumberFormat component on the Settings Phone Form to constrain the phone number field to accept and return phone numbers in the standard US '+1 (XXX) XXX-XXXX' format.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue; previously, the field would accept ANY type of input, so this update restricts that)

# How Has This Been Tested?

I inputted numbers and saw that a phone number was returned in the correct format, and that that phone number displayed for the user after submitting the form. I also attempted to input non-number values and noted that the values could not be entered into the field.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
